### PR TITLE
added counter to track number of remaining tries

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ As a developer, you are tasked with creating a treasure hunt game. The user will
       - Use onClick to call a function restartGame
       - Create a function restartGame to set conditions for board and playing
 - As a user, I can see a counter that shows how many guesses I have left. The counter starts at five and decrements one every time I click on a square that is not the treasure nor the bomb.
+      - Create a state for remaining guesses that initializes to 5
+      - After non-win/loss, decrement remaining guesses
+      - Show counter in the header
 - As a user, I can see a message informing me that I won the game if I select the square that contains the treasure.
 - As a user, I can see a message informing me that I lost the game if I select the square that contains the bomb.
 - As a user, I cannot continue to play the game after I win or lose.

--- a/src/App.js
+++ b/src/App.js
@@ -15,11 +15,15 @@ const App = () => {
             "?",
             "?"
       ])
+      // Create state to track game status
       const [active, setActive] = useState(true)
+
+      // Create state to track remaining guesses
+      const [tries, setTries] = useState(5)
 
       // Create a function to process clicks on the game board
       const processClick = (location) => {
-            if(!active){
+            if(!active || tries === 0){
                   alert("Sorry, the game is over")
             }else if(board[location] === "?"){
                   let guesses = board.filter(value => value === "?").length
@@ -38,6 +42,7 @@ const App = () => {
                               alert("You lose!")
                               break
                         default:
+                              setTries(tries - 1)
                               newChar = "🌲"
                   }
 
@@ -61,12 +66,14 @@ const App = () => {
                   "?"
             ])
             setActive(true)
+            setTries(5)
       }
 
   return (
     <>
       <div className="header">
             <h1>Treasure Hunt Game</h1>
+            <h2>You have {tries} tries remaining.</h2>
             <button onClick={restartGame}>Restart Game</button>
       </div>
       <div className="gameboard">


### PR DESCRIPTION
- As a user, I can see a counter that shows how many guesses I have left. The counter starts at five and decrements one every time I click on a square that is not the treasure nor the bomb.
      - Create a state for remaining guesses that initializes to 5
      - After non-win/loss, decrement remaining guesses
      - Show counter in the header